### PR TITLE
Property decorator support

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,7 +11,7 @@ ignore=
     # Docstring Content
     D400,D401,D402,D405,D406,D407,D408,D409,D410,D411,D412,D413,D414,
     # Type Annotations
-    TYP002,TYP003,TYP101,TYP102,TYP204,TYP206
+    TYP002,TYP003,TYP101,TYP102,TYP103,TYP204,TYP206
 exclude=
     __pycache__,.cache,
     venv,.venv,

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ pip install -e .
 ### Method Annotations
 | ID       | Description                                           |
 |----------|-------------------------------------------------------|
-| `TYP101` | Missing type annotation for `self` in class method    |
+| `TYP101` | Missing type annotation for `self` in method          |
 | `TYP102` | Missing type annotation for `self` in property method |
 | `TYP103` | Missing type annotation for `cls` in classmethod      |
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ pip install -e .
 | `TYP201` | Missing return type annotation for public function    |
 | `TYP202` | Missing return type annotation for protected function |
 | `TYP203` | Missing return type annotation for secret function    |
-| `TYP204` | Missing return type annotation for magic function     |
+| `TYP204` | Missing return type annotation for special method     |
 | `TYP205` | Missing return type annotation for staticmethod       |
 | `TYP206` | Missing return type annotation for classmethod        |
 | `TYP207` | Missing return type annotation for class property     |

--- a/README.md
+++ b/README.md
@@ -34,17 +34,19 @@ $ pip install -e .
 | `TYP003` | Missing type annotation for `**kwargs`        |
 
 ### Method Annotations
-| ID       | Description                                        |
-|----------|----------------------------------------------------|
-| `TYP101` | Missing type annotation for `self` in class method |
-| `TYP102` | Missing type annotation for `cls` in classmethod   |
+| ID       | Description                                           |
+|----------|-------------------------------------------------------|
+| `TYP101` | Missing type annotation for `self` in class method    |
+| `TYP102` | Missing type annotation for `self` in property method |
+| `TYP103` | Missing type annotation for `cls` in classmethod      |
 
 ### Return Annotations
-| ID       | Description                                         |
-|----------|-----------------------------------------------------|
-| `TYP201` | Missing return type annotation for public method    |
-| `TYP202` | Missing return type annotation for protected method |
-| `TYP203` | Missing return type annotation for secret method    |
-| `TYP204` | Missing return type annotation for magic method     |
-| `TYP205` | Missing return type annotation for staticmethod     |
-| `TYP206` | Missing return type annotation for classmethod      |
+| ID       | Description                                           |
+|----------|-------------------------------------------------------|
+| `TYP201` | Missing return type annotation for public function    |
+| `TYP202` | Missing return type annotation for protected function |
+| `TYP203` | Missing return type annotation for secret function    |
+| `TYP204` | Missing return type annotation for magic function     |
+| `TYP205` | Missing return type annotation for staticmethod       |
+| `TYP206` | Missing return type annotation for classmethod        |
+| `TYP207` | Missing return type annotation for class property     |

--- a/flake8_annotations/__init__.py
+++ b/flake8_annotations/__init__.py
@@ -4,7 +4,7 @@ from typing import List, Union
 from flake8_annotations.enums import AnnotationType, ClassDecoratorType, FunctionType
 
 
-__version__ = "2019.0"
+__version__ = "2019.1"
 
 AST_ARG_TYPES = ("args", "vararg", "kwonlyargs", "kwarg")
 AST_FUNCTION_TYPES = Union[ast.FunctionDef, ast.AsyncFunctionDef]

--- a/flake8_annotations/__init__.py
+++ b/flake8_annotations/__init__.py
@@ -120,7 +120,11 @@ class Function:
                 )
 
         # Create an Argument object for the return hint
-        return_arg = Argument("return", node.lineno, node.col_offset, AnnotationType.RETURN)
+        # Get the line number from the line before where the body of the function starts to account
+        # for the presence of decorators
+        def_end_lineno = node.body[0].lineno - 1
+
+        return_arg = Argument("return", def_end_lineno, node.col_offset, AnnotationType.RETURN)
         if node.returns:
             return_arg.has_type_annotation = True
             new_function.is_return_annotated = True

--- a/flake8_annotations/__init__.py
+++ b/flake8_annotations/__init__.py
@@ -8,7 +8,11 @@ __version__ = "2019.0"
 
 AST_ARG_TYPES = ("args", "vararg", "kwonlyargs", "kwarg")
 AST_FUNCTION_TYPES = Union[ast.FunctionDef, ast.AsyncFunctionDef]
-PROPERTY_METHODS = ("setter", "deleter")  # Valid methods for property decorators
+
+# Valid methods for property decorators
+# .getter is included for completeness, even though it overrides the @property decorated method if
+# you use them together
+PROPERTY_METHODS = ("getter", "setter", "deleter")
 
 
 class Argument:

--- a/flake8_annotations/__init__.py
+++ b/flake8_annotations/__init__.py
@@ -147,13 +147,13 @@ class Function:
         Determine the function's FunctionType from its name.
 
         MethodType is determined by the following priority:
-          1. Magic: function name prefixed & suffixed by "__"
+          1. Special: function name prefixed & suffixed by "__"
           2. Private: function name prefixed by "__"
           3. Protected: function name prefixed by "_"
           4. Public: everything else
         """
         if function_name.startswith("__") and function_name.endswith("__"):
-            return FunctionType.MAGIC
+            return FunctionType.SPECIAL
         elif function_name.startswith("__"):
             return FunctionType.PRIVATE
         elif function_name.startswith("_"):
@@ -177,7 +177,7 @@ class Function:
         decorator_attributes = []
         for decorator in function_node.decorator_list:
             # @property, @classmethod, and @staticmethod will be ast.Name objects
-            # property.setter, and property.deleter will be ast.Attribute objects
+            # property.getter, property.setter, and property.deleter will be ast.Attribute objects
             # Other callable decorators will be ast.Call objects, which we're ignoring
             if isinstance(decorator, ast.Name):
                 decorators.append(decorator.id)

--- a/flake8_annotations/__init__.py
+++ b/flake8_annotations/__init__.py
@@ -4,7 +4,7 @@ from typing import List, Union
 from flake8_annotations.enums import AnnotationType, ClassDecoratorType, FunctionType
 
 
-__version__ = "2019.1"
+__version__ = "1.0.0"
 
 AST_ARG_TYPES = ("args", "vararg", "kwonlyargs", "kwarg")
 AST_FUNCTION_TYPES = Union[ast.FunctionDef, ast.AsyncFunctionDef]

--- a/flake8_annotations/checker.py
+++ b/flake8_annotations/checker.py
@@ -22,7 +22,7 @@ class TypeHintChecker:
         This should yield tuples with the following information:
           (line number, column number, message, checker type)
         """
-        visitor = FunctionVisitor()
+        visitor = FunctionVisitor(self.lines)
         visitor.visit(self.tree)
 
         # Iterate over the arguments with missing type hints, by function, and yield linting errors

--- a/flake8_annotations/checker.py
+++ b/flake8_annotations/checker.py
@@ -81,7 +81,7 @@ def _return_error_classifier(
         elif class_decorator_type == enums.ClassDecoratorType.STATICMETHOD:
             return error_codes.TYP205
 
-    if function_type == enums.FunctionType.MAGIC:
+    if function_type == enums.FunctionType.SPECIAL:
         return error_codes.TYP204
     elif function_type == enums.FunctionType.PRIVATE:
         return error_codes.TYP203

--- a/flake8_annotations/checker.py
+++ b/flake8_annotations/checker.py
@@ -70,9 +70,13 @@ def _return_error_classifier(
     function_type: enums.FunctionType,
 ) -> error_codes.Error:
     """Classify return type annotation error."""
-    # Decorated class methods (@classmethod, @staticmethod) have a higher priority than the rest
+    # Decorated class methods (@classmethod, @staticmethod, @property) have a higher priority than
+    # the rest
     if is_class_method:
-        if class_decorator_type == enums.ClassDecoratorType.CLASSMETHOD:
+        if class_decorator_type == enums.ClassDecoratorType.PROPERTY:
+            # Property decorators (property, .getter, .setter, .deleter)
+            return error_codes.TYP207
+        elif class_decorator_type == enums.ClassDecoratorType.CLASSMETHOD:
             return error_codes.TYP206
         elif class_decorator_type == enums.ClassDecoratorType.STATICMETHOD:
             return error_codes.TYP205
@@ -84,6 +88,7 @@ def _return_error_classifier(
     elif function_type == enums.FunctionType.PROTECTED:
         return error_codes.TYP202
     else:
+        # "Regular" function declaration
         return error_codes.TYP201
 
 
@@ -95,11 +100,13 @@ def _argument_error_classifier(
     annotation_type: enums.AnnotationType,
 ) -> error_codes.Error:
     """Classify argument type annotation error."""
-    # Check for regular class methods and @classmethod, @staticmethod is deferred to final check
+    # Check for regular class methods, @property (includes getter, setter, deleter), & @classmethod
     if is_class_method:
         # The first function argument here would be an instance of self or class
         if is_first_arg:
             if class_decorator_type == enums.ClassDecoratorType.CLASSMETHOD:
+                return error_codes.TYP103
+            elif class_decorator_type == enums.ClassDecoratorType.PROPERTY:
                 return error_codes.TYP102
             elif class_decorator_type != enums.ClassDecoratorType.STATICMETHOD:
                 # Regular class method

--- a/flake8_annotations/checker.py
+++ b/flake8_annotations/checker.py
@@ -74,7 +74,7 @@ def _return_error_classifier(
     # the rest
     if is_class_method:
         if class_decorator_type == enums.ClassDecoratorType.PROPERTY:
-            # Property decorators (property, .setter, .deleter)
+            # Property decorators (property, .getter, .setter, .deleter)
             return error_codes.TYP207
         elif class_decorator_type == enums.ClassDecoratorType.CLASSMETHOD:
             return error_codes.TYP206
@@ -100,7 +100,7 @@ def _argument_error_classifier(
     annotation_type: enums.AnnotationType,
 ) -> error_codes.Error:
     """Classify argument type annotation error."""
-    # Check for regular class methods, @property (includes setter, deleter), & @classmethod
+    # Check for regular class methods, @property (includes getter, setter, deleter), & @classmethod
     if is_class_method:
         # The first function argument here would be an instance of self or class
         if is_first_arg:

--- a/flake8_annotations/checker.py
+++ b/flake8_annotations/checker.py
@@ -74,7 +74,7 @@ def _return_error_classifier(
     # the rest
     if is_class_method:
         if class_decorator_type == enums.ClassDecoratorType.PROPERTY:
-            # Property decorators (property, .getter, .setter, .deleter)
+            # Property decorators (property, .setter, .deleter)
             return error_codes.TYP207
         elif class_decorator_type == enums.ClassDecoratorType.CLASSMETHOD:
             return error_codes.TYP206
@@ -100,7 +100,7 @@ def _argument_error_classifier(
     annotation_type: enums.AnnotationType,
 ) -> error_codes.Error:
     """Classify argument type annotation error."""
-    # Check for regular class methods, @property (includes getter, setter, deleter), & @classmethod
+    # Check for regular class methods, @property (includes setter, deleter), & @classmethod
     if is_class_method:
         # The first function argument here would be an instance of self or class
         if is_first_arg:

--- a/flake8_annotations/enums.py
+++ b/flake8_annotations/enums.py
@@ -21,7 +21,7 @@ class ClassDecoratorType(Enum):
 
     CLASSMETHOD = auto()
     STATICMETHOD = auto()
-    PROPERTY = auto()  # Includes @property, .getter, .setter, and .deleter
+    PROPERTY = auto()  # Includes @property, .setter, and .deleter
 
 
 class AnnotationType(Enum):

--- a/flake8_annotations/enums.py
+++ b/flake8_annotations/enums.py
@@ -13,7 +13,7 @@ class FunctionType(Enum):
     PUBLIC = auto()
     PROTECTED = auto()  # Leading single underscore
     PRIVATE = auto()  # Leading double underscore
-    MAGIC = auto()  # Leading & trailing double underscore
+    SPECIAL = auto()  # Leading & trailing double underscore
 
 
 class ClassDecoratorType(Enum):

--- a/flake8_annotations/enums.py
+++ b/flake8_annotations/enums.py
@@ -21,7 +21,7 @@ class ClassDecoratorType(Enum):
 
     CLASSMETHOD = auto()
     STATICMETHOD = auto()
-    PROPERTY = auto()  # Includes @property, .setter, and .deleter
+    PROPERTY = auto()  # Includes @property, .getter, .setter, and .deleter
 
 
 class AnnotationType(Enum):

--- a/flake8_annotations/enums.py
+++ b/flake8_annotations/enums.py
@@ -21,6 +21,7 @@ class ClassDecoratorType(Enum):
 
     CLASSMETHOD = auto()
     STATICMETHOD = auto()
+    PROPERTY = auto()  # Includes @property, .getter, .setter, and .deleter
 
 
 class AnnotationType(Enum):

--- a/flake8_annotations/error_codes.py
+++ b/flake8_annotations/error_codes.py
@@ -82,7 +82,7 @@ class TYP003(Error):
 # Method annotations
 class TYP101(Error):
     def __init__(self, argname: str, lineno: int, col_offset: int):
-        super().__init__("TYP101 Missing type annotation for self in class method")
+        super().__init__("TYP101 Missing type annotation for self in method")
         self.argname = argname
         self.lineno = lineno
         self.col_offset = col_offset
@@ -131,7 +131,7 @@ class TYP203(Error):
 
 class TYP204(Error):
     def __init__(self, argname: str, lineno: int, col_offset: int):
-        super().__init__("TYP204 Missing return type annotation for magic function")
+        super().__init__("TYP204 Missing return type annotation for special method")
         self.argname = argname
         self.lineno = lineno
         self.col_offset = col_offset

--- a/flake8_annotations/error_codes.py
+++ b/flake8_annotations/error_codes.py
@@ -36,7 +36,7 @@ class TYP001(Error):
         self.col_offset = col_offset
 
     def to_flake8(self) -> Tuple[int, int, str, Type]:
-        """Overload super's formatter so we can include argname in the output"""
+        """Overload super's formatter so we can include argname in the output."""
         return (
             self.lineno,
             self.col_offset,
@@ -53,7 +53,7 @@ class TYP002(Error):
         self.col_offset = col_offset
 
     def to_flake8(self) -> Tuple[int, int, str, Type]:
-        """Overload super's formatter so we can include argname in the output"""
+        """Overload super's formatter so we can include argname in the output."""
         return (
             self.lineno,
             self.col_offset,
@@ -90,7 +90,15 @@ class TYP101(Error):
 
 class TYP102(Error):
     def __init__(self, argname: str, lineno: int, col_offset: int):
-        super().__init__("TYP102 Missing type annotation for cls in classmethod")
+        super().__init__("TYP102 Missing type annotation for self in property method")
+        self.argname = argname
+        self.lineno = lineno
+        self.col_offset = col_offset
+
+
+class TYP103(Error):
+    def __init__(self, argname: str, lineno: int, col_offset: int):
+        super().__init__("TYP103 Missing type annotation for cls in classmethod")
         self.argname = argname
         self.lineno = lineno
         self.col_offset = col_offset
@@ -140,6 +148,14 @@ class TYP205(Error):
 class TYP206(Error):
     def __init__(self, argname: str, lineno: int, col_offset: int):
         super().__init__("TYP206 Missing return type annotation for classmethod")
+        self.argname = argname
+        self.lineno = lineno
+        self.col_offset = col_offset
+
+
+class TYP207(Error):
+    def __init__(self, argname: str, lineno: int, col_offset: int):
+        super().__init__("TYP207 Missing return type annotation for class property")
         self.argname = argname
         self.lineno = lineno
         self.col_offset = col_offset

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ assert sys.version_info >= (3, 6, 0), "flake8-annotations requires Python 3.6+"
 setup(
     name="flake8_annotations",
     license="MIT",
-    version="2019.0",
+    version="2019.1",
     description="Flake8 Type Annotation Checks",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ assert sys.version_info >= (3, 6, 0), "flake8-annotations requires Python 3.6+"
 setup(
     name="flake8_annotations",
     license="MIT",
-    version="2019.1",
+    version="1.0.0",
     description="Flake8 Type Annotation Checks",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Add support for property decorators (`@property`, `@foo.getter`, `@foo.setter`, `@foo.deleter`)

Initial testing was done with [this sample code](https://gist.github.com/sco1/f4478d0a7e17adbe95e5105a57b30d65#file-second_test-py), providing the following results:

```
./test.py:4:18: TYP101 Missing type annotation for self in class method
./test.py:4:24: TYP204 Missing return type annotation for magic function
./test.py:8:21: TYP101 Missing type annotation for self in class method
./test.py:8:27: TYP201 Missing return type annotation for public function
./test.py:12:30: TYP101 Missing type annotation for self in class method
./test.py:12:36: TYP202 Missing return type annotation for protected function
./test.py:16:33: TYP101 Missing type annotation for self in class method
./test.py:16:39: TYP203 Missing return type annotation for secret function
./test.py:21:26: TYP103 Missing type annotation for cls in classmethod
./test.py:21:31: TYP206 Missing return type annotation for classmethod
./test.py:26:27: TYP001 Missing type annotation for function argument 'cls'
./test.py:26:32: TYP205 Missing return type annotation for staticmethod
./test.py:31:11: TYP102 Missing type annotation for self in property method
./test.py:31:17: TYP207 Missing return type annotation for class property
./test.py:36:11: TYP102 Missing type annotation for self in property method
./test.py:36:17: TYP001 Missing type annotation for function argument 'value'
./test.py:36:24: TYP207 Missing return type annotation for class property
./test.py:41:11: TYP102 Missing type annotation for self in property method
./test.py:41:17: TYP207 Missing return type annotation for class property
./test.py:46:11: TYP102 Missing type annotation for self in property method
./test.py:46:17: TYP207 Missing return type annotation for class property
./test.py:51:19: TYP001 Missing type annotation for function argument 'a'
./test.py:51:22: TYP201 Missing return type annotation for public function
./test.py:56:28: TYP001 Missing type annotation for function argument 'a'
./test.py:56:31: TYP202 Missing return type annotation for protected function
./test.py:61:31: TYP001 Missing type annotation for function argument 'a'
./test.py:61:34: TYP203 Missing return type annotation for secret function
```

Closes: #20 