### PR TITLE
setuptools fixes and tweaks

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,7 @@ pytest-cov = "~=2.7"
 
 [scripts]
 lint = "flake8"
+check = "python setup.py --quiet check --metadata --strict"
 precommit = "pre-commit install"
 test = "pytest"
 coverage = "pytest --cov=flake8_annotations testing/ --cov-branch --cov-report term-missing"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,24 @@
-import sys
+from setuptools import setup
 
-from setuptools import find_packages, setup
-
-assert sys.version_info >= (3, 6, 0), "flake8-annotations requires Python 3.6+"
 
 setup(
-    name="flake8_annotations",
+    name="flake8-annotations",
     license="MIT",
     version="1.0.0",
     description="Flake8 Type Annotation Checks",
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     author="Python Discord",
     author_email="staff@pythondiscord.com",
     url="https://github.com/python-discord/flake8-annotations",
-    packages=find_packages(),
+    packages=['flake8_annotations'],
     entry_points={
         "flake8.extension": [
             'TYP = flake8_annotations.checker:TypeHintChecker',
         ],
     },
+    python_requires=">=3.6",
+    zip_safe=True,
     classifiers=[
         "Framework :: Flake8",
         "Environment :: Console",
@@ -34,6 +33,10 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Software Development :: Quality Assurance",
     ],
+    project_urls={
+        'Issue tracker': 'https://github.com/python-discord/flake8-annotations/issues',
+        'Discord server': 'https://discord.gg/python',
+    },
     install_requires=[
         "flake8~=3.7.8"
     ],


### PR DESCRIPTION
Some packaging tweaks.

Changes:
- Use python_requires instead of asserting the version. pip will use
python_requires to make an intelligent decision about whether the
package can be installed.
- Remove redundant setup.cfg
- Manually specify packages instead of using find_packages()
- Mark as zip safe (slightly faster wheel builds)
- Add project URLs. These appear on the left side of the PyPI page.

The setuptools documentation has details on the setup arguments: https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords