### PR TITLE
Release v1.1.0

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -17,6 +17,6 @@ exclude=
     __pycache__,.cache,
     venv,.venv,
     build, dist,
-    testing,
+    testing/*,
     error_codes.py
 import-order-style=pycharm

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: I have encountered a bug!
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description the bug you encountered.
+
+If this is something behaving contrary to what you'd expect, please provide your expectation as well.
+
+**To Reproduce**
+Minimal code example to reproduce the behavior:
+
+```py
+Your code here
+```
+
+**Version Information**
+Please provide the full output of `flake8 --version`
+
+```bash
+$ flake8 --version
+Your output here
+```
+
+As well as your Python version:
+```bash
+$ python -V
+Your output here
+```

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an idea for this project!
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+**Description**
+Please provide a clear & concise description of the proposed feature.
+
+**Rationale/Use Case**
+If possible, try to include some example code & a description of how you'd expect the linter to behave.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (`<major>`.`<minor>`.`<patch>`)
+
+## [Unreleased]
+### Added
+* #35: Issue templates
+* #36: Support for PEP 484-style type comments
+* #36: Add `TYP301` for presence of type comment & type annotation for same entity
+* #36: Add `error_code.from_function` class method to generate argument for an entire function
+* #18: PyPI release via GitHub Action
+* #38: Improve `setup.py` metadata
+
+### Fixed
+* #32: Incorrect line number for return values in the presence of multiline docstrings
+* #33: Improper handling of nested functions in class methods
+* `setup.py` dev dependencies out of sync with Pipfile
+* Incorrect order of arguments in `Argument` and `Function` `__repr__` methods
+
+## [v1.0.0] - 2019-09-09
+Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (`<major>`.`<minor>`.`<patch>`)
 
-## [Unreleased]
+## [v1.1.0]
 ### Added
 * #35: Issue templates
 * #36: Support for PEP 484-style type comments

--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 flake8 = "~=3.7.8"
 flake8-annotations = {path = ".",editable = true}
+typed-ast = "~=1.4"
 
 [dev-packages]
 flake8-bugbear = "~=19.8"

--- a/Pipfile
+++ b/Pipfile
@@ -22,6 +22,7 @@ pytest-cov = "~=2.7"
 
 [scripts]
 lint = "flake8"
+check = "python setup.py --quiet check --metadata --strict"
 precommit = "pre-commit install"
 test = "pytest"
 coverage = "pytest --cov=flake8_annotations testing/ --cov-branch --cov-report term-missing"

--- a/Pipfile
+++ b/Pipfile
@@ -22,7 +22,7 @@ pytest-cov = "~=2.7"
 
 [scripts]
 lint = "flake8"
-check = "python setup.py --quiet check --metadata --strict"
+check_metadata = "python setup.py --quiet check --metadata --strict"
 precommit = "pre-commit install"
 test = "pytest"
 coverage = "pytest --cov=flake8_annotations testing/ --cov-branch --cov-report term-missing"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "195bc514dfecfd4bcfca41781e2ddcff7d5a1f235304fc8df6ae1d7cb938f1ef"
+            "sha256": "03c8b86de6b3689d216e952b9aa4889c7ce29c3aff96c3d3d40280e66731ec39"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -53,6 +53,27 @@
                 "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
             ],
             "version": "==2.1.1"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:18511a0b3e7922276346bcb47e2ef9f38fb90fd31cb9223eed42c85d1312344e",
+                "sha256:262c247a82d005e43b5b7f69aff746370538e176131c32dda9cb0f324d27141e",
+                "sha256:2b907eb046d049bcd9892e3076c7a6456c93a25bebfe554e931620c90e6a25b0",
+                "sha256:354c16e5babd09f5cb0ee000d54cfa38401d8b8891eefa878ac772f827181a3c",
+                "sha256:4e0b70c6fc4d010f8107726af5fd37921b666f5b31d9331f0bd24ad9a088e631",
+                "sha256:630968c5cdee51a11c05a30453f8cd65e0cc1d2ad0d9192819df9978984529f4",
+                "sha256:66480f95b8167c9c5c5c87f32cf437d585937970f3fc24386f313a4c97b44e34",
+                "sha256:71211d26ffd12d63a83e079ff258ac9d56a1376a25bc80b1cdcdf601b855b90b",
+                "sha256:95bd11af7eafc16e829af2d3df510cecfd4387f6453355188342c3e79a2ec87a",
+                "sha256:bc6c7d3fa1325a0c6613512a093bc2a2a15aeec350451cbdf9e1d4bffe3e3233",
+                "sha256:cc34a6f5b426748a507dd5d1de4c1978f2eb5626d51326e43280941206c209e1",
+                "sha256:d755f03c1e4a51e9b24d899561fec4ccaf51f210d52abdf8c07ee2849b212a36",
+                "sha256:d7c45933b1bdfaf9f36c579671fec15d25b06c8398f113dab64c18ed1adda01d",
+                "sha256:d896919306dd0aa22d0132f62a1b78d11aaf4c9fc5b3410d3c666b818191630a",
+                "sha256:ffde2fbfad571af120fcbfbbc61c72469e72f550d676c3342492a9dfdefb8f12"
+            ],
+            "index": "pypi",
+            "version": "==1.4.0"
         }
     },
     "develop": {
@@ -208,11 +229,11 @@
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:9ff1b1c5a354142de080b8a4e9803e5d0d59283c93aed808617c787d16768375",
-                "sha256:b7143592e374e50584564794fcb8aaf00a23025f9db866627f89a21491847a8d"
+                "sha256:652234b6ab8f2506ae58e528b6fbcc668831d3cc758e1bc01ef438d328b68cdb",
+                "sha256:6f264986fb88042bc1f0535fa9a557e6a376cfe5679dc77caac7fe8b5d43d05f"
             ],
             "markers": "python_version < '3.8'",
-            "version": "==0.20"
+            "version": "==0.22"
         },
         "junit-xml": {
             "hashes": [
@@ -249,10 +270,10 @@
         },
         "pluggy": {
             "hashes": [
-                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
-                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
+                "sha256:0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6",
+                "sha256:fa5fa1622fa6dd5c030e9cad086fa19ef6a0cf6d7a2d12318e10cb49d6d68f34"
             ],
-            "version": "==0.12.0"
+            "version": "==0.13.0"
         },
         "pre-commit": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can verify it's being picked up by invoking the following in your shell:
 
 ```bash
 $ flake8 --version
-3.7.8 (flake8-annotations: 1.0.0, mccabe: 0.6.1, pycodestyle: 2.5.0, pyflakes: 2.1.1) CPython 3.7.4 on Darwin
+3.7.8 (flake8-annotations: 1.0.1, mccabe: 0.6.1, pycodestyle: 2.5.0, pyflakes: 2.1.1) CPython 3.7.4 on Darwin
 ```
 
 ## Table of Warnings
@@ -88,12 +88,12 @@ e.g.
 
 ```
 ----------- coverage: platform win32, python 3.7.4-final-0 -----------
-Name                                Stmts   Miss  Cover   Missing
------------------------------------------------------------------
-flake8_annotations\__init__.py        110      1    99%   164
-flake8_annotations\checker.py          57      0   100%
-flake8_annotations\enums.py            15      0   100%
-flake8_annotations\error_codes.py      85      0   100%
------------------------------------------------------------------
-TOTAL                                 267      1    99%
+Name                                Stmts   Miss Branch BrPart  Cover   Missing
+-------------------------------------------------------------------------------
+flake8_annotations\__init__.py        108      0     38      0    99%   164
+flake8_annotations\checker.py          57      0     30      0   100%
+flake8_annotations\enums.py            15      0      0      0   100%
+flake8_annotations\error_codes.py      85      0      0      0   100%
+-------------------------------------------------------------------------------
+TOTAL                                 265      0     68      0    99%
 ```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can verify it's being picked up by invoking the following in your shell:
 
 ```bash
 $ flake8 --version
-3.7.8 (flake8-annotations: 1.0.1, mccabe: 0.6.1, pycodestyle: 2.5.0, pyflakes: 2.1.1) CPython 3.7.4 on Darwin
+3.7.8 (flake8-annotations: 1.1.0, mccabe: 0.6.1, pycodestyle: 2.5.0, pyflakes: 2.1.1) CPython 3.7.4 on Darwin
 ```
 
 ## Table of Warnings

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 [![Discord](https://discordapp.com/api/guilds/267624335836053506/embed.png)](https://discord.gg/2B963hn)
 
 
-`flake8-annotations` is a plugin for [Flake8](http://flake8.pycqa.org/en/latest/) that detects the absence of [PEP 3107-style](https://www.python.org/dev/peps/pep-3107/) function annotations.
+`flake8-annotations` is a plugin for [Flake8](http://flake8.pycqa.org/en/latest/) that detects the absence of [PEP 3107-style](https://www.python.org/dev/peps/pep-3107/) function annotations and [PEP 484-style](https://www.python.org/dev/peps/pep-0484/#type-comments) type comments  (see: [Caveats](#Caveats-for-PEP-484-style-Type-Comments)).
 
-What this won't do: Check variable annotations (see: [PEP 526](https://www.python.org/dev/peps/pep-0526/)), check type comments (see: [PEP 484](https://www.python.org/dev/peps/pep-0484/#type-comments)), or replace [mypy's](http://mypy-lang.org/) compile-time type checking.
+What this won't do: Check variable annotations (see: [PEP 526](https://www.python.org/dev/peps/pep-0526/)), respect stub files, or replace [mypy's](http://mypy-lang.org/) compile-time type checking.
 
 ## Installation
 
@@ -49,6 +49,61 @@ $ flake8 --version
 | `TYP204` | Missing return type annotation for special method     |
 | `TYP205` | Missing return type annotation for staticmethod       |
 | `TYP206` | Missing return type annotation for classmethod        |
+
+### Type Comments
+| ID       | Description                                               |
+|----------|-----------------------------------------------------------|
+| `TYP301` | PEP 484 disallows both type annotations and type comments |
+
+## Caveats for PEP 484-style Type Comments
+### Function type comments
+Function type comments are assumed to contain both argument and return type hints
+
+Yes:
+```py
+# type: (int, int) -> bool
+```
+
+No:
+```py
+# type: (int, int)
+```
+
+Python cannot parse the latter and will raise `SyntaxError: unexpected EOF while parsing`
+
+### Mixing argument type comments and function type comments
+Support is provided for mixing argument and function type comments, provided that the function type comment use an Ellipsis for the arguments.
+
+```py
+def foo(
+    arg1,  # type: bool
+    arg2,  # type: bool
+):  # type: (...) -> bool
+    pass
+```
+
+Ellipes are ignored by `flake8-annotations` parser.
+
+**Note:** If present, function type comments will override any argument type comments.
+
+### Partial type comments
+Partially type hinted functions are supported
+
+For example:
+
+```py
+def foo(arg1, arg2):
+    # type: (bool) -> bool
+    pass
+```
+Will show `arg2` as missing a type hint.
+
+```py
+def foo(arg1, arg2):
+    # type: (..., bool) -> bool
+    pass
+```
+Will show `arg1` as missing a type hint.
 
 ## Contributing
 Please take some time to read through our [contributing guidelines](CONTRIBUTING.md) before helping us with this project.

--- a/flake8_annotations/__init__.py
+++ b/flake8_annotations/__init__.py
@@ -294,7 +294,6 @@ class FunctionVisitor(ast.NodeVisitor):
         Note: This will not contain class methods, these are included in the body of ClassDef
         statements
         """
-        print(ast.dump(node))
         self.function_definitions.append(Function.from_function_node(node, self.lines))
         self.generic_visit(node)  # Walk through any nested functions
 

--- a/flake8_annotations/__init__.py
+++ b/flake8_annotations/__init__.py
@@ -156,9 +156,16 @@ class Function:
         # Get the line number from the line before where the body of the function starts to account
         # for the presence of decorators
         def_end_lineno = node.body[0].lineno - 1
-        # Calculate the column offset of the end of the function definition by finding where : is
-        # Lineno is 1-indexed, the line string is 0-indexed
-        def_end_col_offset = lines[def_end_lineno - 1].find(":") + 1
+        while True:
+            # To account for multiline docstrings, rewind through the lines until we find the line
+            # containing the :
+            colon_loc = lines[def_end_lineno - 1].find(":")
+            if colon_loc == -1:
+                def_end_lineno -= 1
+            else:
+                # Lineno is 1-indexed, the line string is 0-indexed
+                def_end_col_offset = colon_loc + 1
+                break
 
         return_arg = Argument("return", def_end_lineno, def_end_col_offset, AnnotationType.RETURN)
         if node.returns:

--- a/flake8_annotations/__init__.py
+++ b/flake8_annotations/__init__.py
@@ -5,7 +5,7 @@ from typing import List, Union
 from flake8_annotations.enums import AnnotationType, ClassDecoratorType, FunctionType
 from typed_ast import _ast3, ast3 as ast
 
-__version__ = "1.0.1"
+__version__ = "1.1.0"
 
 AST_ARG_TYPES = ("args", "vararg", "kwonlyargs", "kwarg")
 AST_FUNCTION_TYPES = Union[ast.FunctionDef, ast.AsyncFunctionDef]

--- a/flake8_annotations/__init__.py
+++ b/flake8_annotations/__init__.py
@@ -5,7 +5,7 @@ from typing import List, Union
 from flake8_annotations.enums import AnnotationType, ClassDecoratorType, FunctionType
 
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 AST_ARG_TYPES = ("args", "vararg", "kwonlyargs", "kwarg")
 AST_FUNCTION_TYPES = Union[ast.FunctionDef, ast.AsyncFunctionDef]

--- a/flake8_annotations/__init__.py
+++ b/flake8_annotations/__init__.py
@@ -255,8 +255,6 @@ class FunctionVisitor(ast.NodeVisitor):
 
         Class methods will all be contained in the body of the node
         """
-        # Use ast.NodeVisitor.generic_visit to punt class method processing to the other function
-        # visitors
         method_nodes = [
             child_node
             for child_node in node.body
@@ -268,6 +266,10 @@ class FunctionVisitor(ast.NodeVisitor):
                 for method_node in method_nodes
             ]
         )
+
+        # Use ast.NodeVisitor.generic_visit to start down the nested method chain
+        for sub_node in node.body:
+            self.generic_visit(sub_node)
 
     @classmethod
     def parse_file(cls, src_filepath: Path) -> "FunctionVisitor":  # Need to quote for 3.6 compat

--- a/flake8_annotations/checker.py
+++ b/flake8_annotations/checker.py
@@ -1,9 +1,9 @@
-import ast
 from functools import lru_cache
 from pathlib import Path
 from typing import Generator, List, Tuple
 
 from flake8_annotations import Argument, Function, FunctionVisitor, __version__, enums, error_codes
+from typed_ast import ast3 as ast
 
 
 class TypeHintChecker:
@@ -12,9 +12,11 @@ class TypeHintChecker:
     name = "function-type-annotations"
     version = __version__
 
-    def __init__(self, tree: ast.Module, lines: List[str]):
-        self.tree = tree
-        self.lines = lines
+    def __init__(self, tree: ast.Module, filename: str):
+        # Unfortunately no way that I can find around requesting the ast-parsed tree from flake8
+        # Removing tree unregisters the plugin, and per the documentation the alternative is
+        # requesting per-line information
+        self.tree, self.lines = self.load_file(Path(filename))
 
     def run(self) -> Generator[error_codes.Error, None, None]:
         """
@@ -31,12 +33,30 @@ class TypeHintChecker:
         #
         # Flake8 handles all noqa and error code ignore configurations after the error is yielded
         for function in visitor.function_definitions:
+            # Create a sentinel to check for mixed hint styles
+            if function.has_type_comment:
+                has_type_comment = True
+            else:
+                has_type_comment = False
+
+            # Iterate over annotated args to detect mixing of type annotations and type comments
+            # Emit this only once per function definition
+            for arg in function.get_annotated_arguments():
+                if arg.has_type_comment:
+                    has_type_comment = True
+
+                if has_type_comment and arg.has_3107_annotation:
+                    # Short-circuit check for mixing of type comments & 3107-style annotations
+                    yield error_codes.TYP301.from_function(function).to_flake8()
+                    break
+
+            # Yield explicit errors for arguments that are missing annotations
             for arg in function.get_missed_annotations():
                 yield classify_error(function, arg).to_flake8()
 
     @staticmethod
     def load_file(src_filepath: Path) -> Tuple[ast.Module, List[str]]:
-        """Parse the provided Python file and return an (AST, source) tuple."""
+        """Parse the provided Python file and return an (typed AST, source) tuple."""
         with src_filepath.open("r", encoding="utf-8") as f:
             src = f.read()
 

--- a/flake8_annotations/checker.py
+++ b/flake8_annotations/checker.py
@@ -9,7 +9,7 @@ from typed_ast import ast3 as ast
 class TypeHintChecker:
     """Top level checker for linting the presence of type hints in function definitions."""
 
-    name = "function-type-annotations"
+    name = "flake8-annotations"
     version = __version__
 
     def __init__(self, tree: ast.Module, filename: str):

--- a/flake8_annotations/error_codes.py
+++ b/flake8_annotations/error_codes.py
@@ -1,6 +1,6 @@
 from typing import Tuple, Type
 
-from flake8_annotations import Argument, checker
+from flake8_annotations import Argument, Function, checker
 
 
 class Error:
@@ -16,6 +16,11 @@ class Error:
     def from_argument(cls, argument: Argument):
         """Set error metadata from the input Argument object."""
         return cls(argument.argname, argument.lineno, argument.col_offset)
+
+    @classmethod
+    def from_function(cls, function: Function):
+        """Set error metadata from the input Function object."""
+        return cls(function.name, function.lineno, function.col_offset)
 
     def to_flake8(self) -> Tuple[int, int, str, Type]:
         """
@@ -140,6 +145,15 @@ class TYP205(Error):
 class TYP206(Error):
     def __init__(self, argname: str, lineno: int, col_offset: int):
         super().__init__("TYP206 Missing return type annotation for classmethod")
+        self.argname = argname
+        self.lineno = lineno
+        self.col_offset = col_offset
+
+
+# Type comments
+class TYP301(Error):
+    def __init__(self, argname: str, lineno: int, col_offset: int):
+        super().__init__("TYP301 PEP 484 disallows both type annotations and type comments")
         self.argname = argname
         self.lineno = lineno
         self.col_offset = col_offset

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name="flake8-annotations",
     license="MIT",
-    version="1.0.1",
+    version="1.1.0",
     description="Flake8 Type Annotation Checks",
     long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -1,25 +1,24 @@
-import sys
+from setuptools import setup
 
-from setuptools import find_packages, setup
-
-assert sys.version_info >= (3, 6, 0), "flake8-annotations requires Python 3.6+"
 
 setup(
-    name="flake8_annotations",
+    name="flake8-annotations",
     license="MIT",
     version="1.0.1",
     description="Flake8 Type Annotation Checks",
-    long_description=open("README.md").read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     author="Python Discord",
     author_email="staff@pythondiscord.com",
     url="https://github.com/python-discord/flake8-annotations",
-    packages=find_packages(),
+    packages=['flake8_annotations'],
     entry_points={
         "flake8.extension": [
             'TYP = flake8_annotations.checker:TypeHintChecker',
         ],
     },
+    python_requires=">=3.6",
+    zip_safe=True,
     classifiers=[
         "Framework :: Flake8",
         "Environment :: Console",
@@ -34,6 +33,10 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
         "Topic :: Software Development :: Quality Assurance",
     ],
+    project_urls={
+        'Issue tracker': 'https://github.com/python-discord/flake8-annotations/issues',
+        'Discord server': 'https://discord.gg/python',
+    },
     install_requires=[
         "flake8~=3.7.8"
     ],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ assert sys.version_info >= (3, 6, 0), "flake8-annotations requires Python 3.6+"
 setup(
     name="flake8_annotations",
     license="MIT",
-    version="1.0.0",
+    version="1.0.1",
     description="Flake8 Type Annotation Checks",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
@@ -39,12 +39,17 @@ setup(
     ],
     extras_require={
         "dev": [
-            "flake8-bugbear~=19.3",
-            "flake8-docstrings~=1.3",
+            "flake8-bugbear~=19.8",
+            "flake8-docstrings~=1.4",
+            "flake8-formatter-junit-xml~=0.0",
             "flake8-import-order~=0.18",
             "flake8-string-format~=0.2",
             "flake8-tidy-imports~=2.0",
             "flake8-todo~=0.7",
+            "pre-commit~=1.18",
+            "pytest~=5.1",
+            "pytest-check~=0.3",
+            "pytest-cov~=2.7",
         ]
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,8 @@ setup(
         'Discord server': 'https://discord.gg/python',
     },
     install_requires=[
-        "flake8~=3.7.8"
+        "flake8~=3.7.8",
+        "typed-ast~=1.4"
     ],
     extras_require={
         "dev": [

--- a/testing/classifier_object_attributes.py
+++ b/testing/classifier_object_attributes.py
@@ -85,3 +85,21 @@ argument_classifications = {
     AT(False, True, None, AnnotationType.KWONLYARGS): error_codes.TYP001,
     AT(False, False, None, AnnotationType.KWONLYARGS): error_codes.TYP001,
 }
+
+# Build a dictionary for the type comment testing code defs & whether a TYP301 error is expected
+class TypeHintFun(NamedTuple):
+    name: str
+    emits_TYP301: bool
+
+
+mixed_type_comment_classifications = {
+    4: TypeHintFun("full_function_comment", False),
+    9: TypeHintFun("partial_function_comment_no_ellipsis", False),
+    14: TypeHintFun("partial_function_comment_with_ellipsis", False),
+    19: TypeHintFun("argument_comments_ellipsis_function_comment", False),
+    26: TypeHintFun("argument_comments_no_function_comment", False),
+    33: TypeHintFun("mixed_argument_hint_types", True),
+    40: TypeHintFun("duplicate_argument_hint_types", True),
+    47: TypeHintFun("arg_comment_return_annotation_hint_types", True),
+    54: TypeHintFun("arg_annotation_return_comment_hint_types", True),
+}

--- a/testing/code/all_functions.py
+++ b/testing/code/all_functions.py
@@ -21,6 +21,18 @@ def __special_fun__():
     pass
 
 
+def foo() -> None:
+    def nested_public_fun():
+        def double_nested_public_fun():
+            pass
+
+
+def foo() -> None:
+    def nested_public_fun_return_annotated() -> None:
+        def double_nested_public_fun_return_annotated() -> None:
+            pass
+
+
 async def async_public_fun():
     pass
 
@@ -39,6 +51,18 @@ async def __async_private_fun():
 
 async def __async_special_fun__():
     pass
+
+
+async def foo() -> None:
+    async def nested_async_public_fun():
+        async def double_nested_async_public_fun():
+            pass
+
+
+async def foo() -> None:
+    async def nested_async_public_fun_return_annotated() -> None:
+        async def double_nested_async_public_fun_return_annotated() -> None:
+            pass
 
 
 class Foo:
@@ -113,3 +137,13 @@ class Foo:
     @staticmethod
     async def decorated_callable_async_staticmethod():
         pass
+
+    def foo() -> None:
+        def nested_method():
+            def double_nested_method():
+                pass
+
+    async def foo() -> None:
+        async def nested_async_method():
+            async def double_nested_async_method():
+                pass

--- a/testing/code/column_line_numbers.py
+++ b/testing/code/column_line_numbers.py
@@ -3,11 +3,13 @@ Check for column offset & line number correctness.
 
 Should yield:
 
-16:9: TYP001 Missing type annotation for function argument 'x'
-16:12: TYP201 Missing return type annotation for public function
-24:5: TYP001 Missing type annotation for function argument 'x'
-25:5: TYP001 Missing type annotation for function argument 'y'
-26:3: TYP201 Missing return type annotation for public function
+20:9: TYP001 Missing type annotation for function argument 'x'
+20:12: TYP201 Missing return type annotation for public function
+28:5: TYP001 Missing type annotation for function argument 'x'
+29:5: TYP001 Missing type annotation for function argument 'y'
+30:3: TYP201 Missing return type annotation for public function
+34:10: TYP201 Missing return type annotation for public function
+39:11: TYP201 Missing return type annotation for public function
 
 Note: Column offsets are 0-indexed when yielded by our checker; flake8 adds 1 when emitted
 Note: Column offsets and line numbers are hard-coded in the testing suite, ensure these are updated
@@ -26,4 +28,18 @@ def foo(
     x,
     y
 ):
+    pass
+
+
+def baz():
+    """A docstring."""
+    pass
+
+
+def snek():
+    """
+    Some.
+
+    Multiline docstring
+    """
     pass

--- a/testing/code/type_comments.py
+++ b/testing/code/type_comments.py
@@ -1,0 +1,58 @@
+"""Check for correct parsing of PEP 484-style type comments."""
+
+
+def full_function_comment(arg1, arg2):
+    # type: (int, int) -> int
+    pass
+
+
+def partial_function_comment_no_ellipsis(arg1, arg2):
+    # type: (int) -> int
+    pass
+
+
+def partial_function_comment_with_ellipsis(arg1, arg2):
+    # type: (..., int) -> int
+    pass
+
+
+def argument_comments_ellipsis_function_comment(
+    arg1,  # type: int
+    arg2,  # type: int
+):  # type: (...) -> int
+    pass
+
+
+def argument_comments_no_function_comment(
+    arg1,  # type: int
+    arg2,  # type: int
+):
+    pass
+
+
+def mixed_argument_hint_types(
+    arg1,  # type: int
+    arg2: int,
+):
+    pass
+
+
+def duplicate_argument_hint_types(
+    arg1,  # type: int
+    arg2: int,  # type: int
+):
+    pass
+
+
+def arg_comment_return_annotation_hint_types(
+    arg1,  # type: int
+    arg2,  # type: int
+) -> int:
+    pass
+
+
+def arg_annotation_return_comment_hint_types(
+    arg1: int,
+    arg2: int,
+):  # type: (...) -> int
+    pass

--- a/testing/parser_object_attributes.py
+++ b/testing/parser_object_attributes.py
@@ -8,7 +8,9 @@ from flake8_annotations.enums import AnnotationType, ClassDecoratorType, Functio
 # Note: For testing purposes, lineno and col_offset are ignored so these are set to dummy values
 # using partial objects
 untyped_arg = partial(Argument, lineno=0, col_offset=0, has_type_annotation=False)
-typed_arg = partial(Argument, lineno=0, col_offset=0, has_type_annotation=True)
+typed_arg = partial(
+    Argument, lineno=0, col_offset=0, has_type_annotation=True, has_3107_annotation=True
+)
 parsed_arguments = {
     "all_args_untyped": [
         untyped_arg(argname="arg", annotation_type=AnnotationType.ARGS),

--- a/testing/parser_object_attributes.py
+++ b/testing/parser_object_attributes.py
@@ -45,6 +45,20 @@ parsed_functions = {
     "__private_fun": nonclass_func(name="__private_fun", function_type=FunctionType.PRIVATE),
     "__special_fun__": nonclass_func(name="__special_fun__", function_type=FunctionType.SPECIAL),
     "async_public_fun": nonclass_func(name="async_public_fun", function_type=FunctionType.PUBLIC),
+    "nested_public_fun": nonclass_func(name="nested_public_fun", function_type=FunctionType.PUBLIC),
+    "double_nested_public_fun": nonclass_func(
+        name="double_nested_public_fun", function_type=FunctionType.PUBLIC
+    ),
+    "nested_public_fun_return_annotated": nonclass_func(
+        name="nested_public_fun_return_annotated",
+        function_type=FunctionType.PUBLIC,
+        is_return_annotated=True,
+    ),
+    "double_nested_public_fun_return_annotated": nonclass_func(
+        name="double_nested_public_fun_return_annotated",
+        function_type=FunctionType.PUBLIC,
+        is_return_annotated=True,
+    ),
     "async_public_fun_return_annotated": nonclass_func(
         name="async_public_fun_return_annotated",
         function_type=FunctionType.PUBLIC,
@@ -58,6 +72,22 @@ parsed_functions = {
     ),
     "__async_special_fun__": nonclass_func(
         name="__async_special_fun__", function_type=FunctionType.SPECIAL
+    ),
+    "nested_async_public_fun": nonclass_func(
+        name="nested_async_public_fun", function_type=FunctionType.PUBLIC
+    ),
+    "double_nested_async_public_fun": nonclass_func(
+        name="double_nested_async_public_fun", function_type=FunctionType.PUBLIC
+    ),
+    "nested_async_public_fun_return_annotated": nonclass_func(
+        name="nested_async_public_fun_return_annotated",
+        function_type=FunctionType.PUBLIC,
+        is_return_annotated=True,
+    ),
+    "double_nested_async_public_fun_return_annotated": nonclass_func(
+        name="double_nested_async_public_fun_return_annotated",
+        function_type=FunctionType.PUBLIC,
+        is_return_annotated=True,
     ),
     "decorated_noncallable_method": class_func(
         name="decorated_noncallable_method",
@@ -138,5 +168,15 @@ parsed_functions = {
         name="decorated_callable_async_staticmethod",
         function_type=FunctionType.PUBLIC,
         class_decorator_type=ClassDecoratorType.STATICMETHOD,
+    ),
+    "nested_method": nonclass_func(name="nested_method", function_type=FunctionType.PUBLIC),
+    "double_nested_method": nonclass_func(
+        name="double_nested_method", function_type=FunctionType.PUBLIC
+    ),
+    "nested_async_method": nonclass_func(
+        name="nested_async_method", function_type=FunctionType.PUBLIC
+    ),
+    "double_nested_async_method": nonclass_func(
+        name="double_nested_async_method", function_type=FunctionType.PUBLIC
     ),
 }

--- a/testing/printed_object_formatting.py
+++ b/testing/printed_object_formatting.py
@@ -24,23 +24,23 @@ formatting_test_cases = {
     "arg": FormatTestCase(
         arg(argname="test_arg"),
         "<Argument: test_arg, Annotated: False>",
-        "Argument('test_arg', 0, 0, AnnotationType.ARGS, False)",
+        "Argument('test_arg', 0, 0, AnnotationType.ARGS, False, False, False)",
     ),
     "func_no_args": FormatTestCase(
         func(args=[arg(argname="return")]),
         "<Function: test_func, Args: [<Argument: return, Annotated: False>]>",
         (
-            "Function('test_func', 0, 0, False, FunctionType.PUBLIC, None, "
-            "[Argument('return', 0, 0, AnnotationType.ARGS, False)], False)"
+            "Function('test_func', 0, 0, FunctionType.PUBLIC, False, None, False, False, "
+            "[Argument('return', 0, 0, AnnotationType.ARGS, False, False, False)])"
         ),
     ),
     "func_has_arg": FormatTestCase(
         func(args=[arg(argname="foo"), arg(argname="return")]),
         "<Function: test_func, Args: [<Argument: foo, Annotated: False>, <Argument: return, Annotated: False>]>",  # noqa
         (
-            "Function('test_func', 0, 0, False, FunctionType.PUBLIC, None, "
-            "[Argument('foo', 0, 0, AnnotationType.ARGS, False), "
-            "Argument('return', 0, 0, AnnotationType.ARGS, False)], False)"
+            "Function('test_func', 0, 0, FunctionType.PUBLIC, False, None, False, False, "
+            "[Argument('foo', 0, 0, AnnotationType.ARGS, False, False, False), "
+            "Argument('return', 0, 0, AnnotationType.ARGS, False, False, False)])"
         ),
     ),
 }

--- a/testing/test_classifier.py
+++ b/testing/test_classifier.py
@@ -1,8 +1,10 @@
+from pathlib import Path
 from typing import Tuple
 
 import pytest
+import pytest_check as check
 from flake8_annotations import Argument, Function
-from flake8_annotations.checker import classify_error
+from flake8_annotations.checker import TypeHintChecker, classify_error
 from flake8_annotations.enums import AnnotationType
 from flake8_annotations.error_codes import Error
 from testing import classifier_object_attributes
@@ -90,3 +92,25 @@ class TestArgumentClassifier:
         """Test missing argument annotation error codes."""
         test_function, test_argument, error_object = function_builder
         assert isinstance(classify_error(test_function, test_argument), error_object)
+
+
+class MixedTypeHintClassifier:
+    """Test for correct classification of mixed type comments & type annotations."""
+
+    src_filepath = Path("./testing/code/type_comments.py")
+    checker_instance = TypeHintChecker(None, src_filepath)
+    errors = checker_instance.run()
+
+    @pytest.fixture(params=errors)
+    def yielded_error(self, request) -> classifier_object_attributes.TypeHintFun:  # noqa
+        """
+        Build a fixture for the error codes emitted from parsing the type comments test code.
+
+        Provide a (TYP301, TypeHintFun) tuple for functions that yield a TYP301 linting error.
+        """
+        lineno = request[0]
+        return classifier_object_attributes.mixed_type_comment_classifications[lineno]
+
+    def test_argument(self, yielded_fun: classifier_object_attributes.TypeHintFun) -> None:
+        """Test for correct classification of mixed type comments & type annotations."""
+        check.is_true(yielded_fun.emits_TYP301)

--- a/testing/test_column_line_numbers.py
+++ b/testing/test_column_line_numbers.py
@@ -13,7 +13,7 @@ TEST_FILE = Path("./testing/code/column_line_numbers.py")
 # (line, column) tuples where we should get linting errors in the test file
 # Line numbers are 1-indexed
 # Column offsets are 0-indexed when yielded by our checker; flake8 adds 1 when emitted
-SHOULD_ERROR = ((18, 8), (18, 11), (26, 4), (27, 4), (28, 2))
+SHOULD_ERROR = ((20, 8), (20, 11), (28, 4), (29, 4), (30, 2), (34, 10), (39, 11))
 ERROR_CODE = Tuple[int, int, str, checker.TypeHintChecker]
 
 

--- a/testing/test_column_line_numbers.py
+++ b/testing/test_column_line_numbers.py
@@ -1,4 +1,3 @@
-import ast
 from itertools import zip_longest
 from pathlib import Path
 from typing import Generator, Tuple
@@ -6,6 +5,7 @@ from typing import Generator, Tuple
 import pytest
 import pytest_check as check
 from flake8_annotations import checker
+from typed_ast import ast3 as ast
 
 
 TEST_FILE = Path("./testing/code/column_line_numbers.py")
@@ -20,8 +20,8 @@ ERROR_CODE = Tuple[int, int, str, checker.TypeHintChecker]
 @pytest.fixture
 def parsed_errors(src_filepath: Path = TEST_FILE) -> Generator[ERROR_CODE, None, None]:
     """Create a fixture for the error codes emitted by our testing code."""
-    tree, lines = checker.TypeHintChecker.load_file(TEST_FILE)
-    return checker.TypeHintChecker(tree, lines).run()
+    tree = checker.TypeHintChecker.load_file(src_filepath)
+    return checker.TypeHintChecker(tree, src_filepath).run()
 
 
 def test_lineno(parsed_errors: Generator[ERROR_CODE, None, None]) -> None:

--- a/testing/test_flake8_format.py
+++ b/testing/test_flake8_format.py
@@ -18,6 +18,7 @@ ALL_ERROR_CODES = (
     error_codes.TYP204,
     error_codes.TYP205,
     error_codes.TYP206,
+    error_codes.TYP301,
 )
 
 

--- a/testing/test_parser.py
+++ b/testing/test_parser.py
@@ -69,12 +69,14 @@ class TestArgumentParsing:
           * argname
           * annotation_type
           * has_type_annotation
+          * has_3107_annotation
         """
         return all(
             (
                 arg_a.argname == arg_b.argname,
                 arg_a.annotation_type == arg_b.annotation_type,
                 arg_a.has_type_annotation == arg_b.has_type_annotation,
+                arg_a.has_3107_annotation == arg_b.has_3107_annotation,
             )
         )
 

--- a/testing/test_type_comments.py
+++ b/testing/test_type_comments.py
@@ -1,0 +1,77 @@
+from itertools import zip_longest
+from pathlib import Path
+from typing import List, Tuple, Union
+
+import pytest
+import pytest_check as check
+from flake8_annotations import Argument, Function, FunctionVisitor
+from testing import type_comment_parser_object_attributes
+from testing.test_parser import _find_matching_function
+
+ARG_FIXTURE_TYPE = Tuple[List[Argument], List[Argument], str]
+
+
+class TestArgumentParsing:
+    """Test for proper argument parsing from source."""
+
+    src_filepath = Path("./testing/code/type_comments.py")
+    visitor = FunctionVisitor.parse_file(src_filepath)
+
+    @pytest.fixture(params=type_comment_parser_object_attributes.parsed_arguments.keys())
+    def argument_lists(self, request) -> ARG_FIXTURE_TYPE:  # noqa
+        """
+        Build a pair of lists of arguments to compare and return as a (truth, parsed) tuple.
+
+        `parser_object_attributes.parsed_arguments` is a dictionary of the arguments that should be
+        parsed out of the testing source code:
+          * Keys are the function name, as str
+          * Values are a list of Argument objects that should be parsed from the function definition
+
+        A list of parsed Argument objects is taken from the class-level source parser
+
+        The function name is also returned in order to provide a more verbose message for a failed
+        assertion
+        """
+        truth_arguments = type_comment_parser_object_attributes.parsed_arguments[request.param]
+
+        matching_func = _find_matching_function(self.visitor.function_definitions, request.param)
+        if matching_func:
+            parsed_arguments = matching_func.args
+        else:
+            # We shouldn't ever get here, but add as a catch-all
+            parsed_arguments = None
+
+        return truth_arguments, parsed_arguments, request.param
+
+    def test_argument_parsing(self, argument_lists: ARG_FIXTURE_TYPE) -> None:
+        """
+        Test argument parsing of the testing source code.
+
+        Argument objects are provided as a tuple of (truth, source) lists
+        """
+        for truth_arg, parsed_arg in zip_longest(*argument_lists[:2]):
+            failure_msg = (
+                f"Comparison check failed for arg '{parsed_arg.argname}' in '{argument_lists[2]}'"
+            )
+            check.is_true(self._is_same_arg(truth_arg, parsed_arg), msg=f"{repr(truth_arg)}\n{repr(parsed_arg)}")
+
+    @staticmethod
+    def _is_same_arg(arg_a: Argument, arg_b: Argument) -> bool:
+        """
+        Compare two Argument objects for "equality."
+
+        Because we are testing argument parsing in another test, we can make this comparison less
+        fragile by ignoring line & column indices and instead comparing only the following:
+          * argname
+          * has_type_annotation
+          * has_3107_annotation
+          * has_type_comment
+        """
+        return all(
+            (
+                arg_a.argname == arg_b.argname,
+                arg_a.has_type_annotation == arg_b.has_type_annotation,
+                arg_a.has_3107_annotation == arg_b.has_3107_annotation,
+                arg_a.has_type_comment == arg_b.has_type_comment
+            )
+        )

--- a/testing/test_variable_formatting.py
+++ b/testing/test_variable_formatting.py
@@ -1,4 +1,3 @@
-import ast
 import re
 from collections import defaultdict
 from pathlib import Path
@@ -6,6 +5,7 @@ from typing import List, Tuple
 
 import pytest
 from flake8_annotations import checker
+from typed_ast import ast3 as ast
 
 TEST_FILE = Path("./testing/code/variable_formatting.py")
 ERROR_CODE_TYPE = Tuple[int, int, str, checker.TypeHintChecker]
@@ -36,10 +36,10 @@ def _simplify_error(error_code: ERROR_CODE_TYPE) -> SIMPLE_ERROR_CODE:
 class TestArgumentFormatting:
     """Testing class for containerizing parsed error codes & running the fixtured tests."""
 
-    tree, lines = checker.TypeHintChecker.load_file(TEST_FILE)
+    tree= checker.TypeHintChecker.load_file(TEST_FILE)
 
     batched_error_codes = defaultdict(list)
-    for error in checker.TypeHintChecker(tree, lines).run():
+    for error in checker.TypeHintChecker(tree, TEST_FILE).run():
         code, arg_name = _simplify_error(error)
         batched_error_codes[code].append(arg_name)
 

--- a/testing/type_comment_parser_object_attributes.py
+++ b/testing/type_comment_parser_object_attributes.py
@@ -1,0 +1,76 @@
+from functools import partial
+
+from flake8_annotations import Argument
+from flake8_annotations.enums import AnnotationType
+
+untyped_arg = partial(
+    Argument,
+    lineno=0,
+    col_offset=0,
+    annotation_type=AnnotationType.ARGS,
+    has_type_annotation=False,
+    has_type_comment=False,
+    has_3107_annotation=False,
+)
+typed_arg = partial(
+    Argument,
+    lineno=0,
+    col_offset=0,
+    annotation_type=AnnotationType.ARGS,
+    has_type_annotation=True,
+    has_type_comment=True,
+    has_3107_annotation=False,
+)
+
+parsed_arguments = {
+    "full_function_comment": [
+        typed_arg(argname="arg1"),
+        typed_arg(argname="arg2"),
+        typed_arg(argname="return", annotation_type=AnnotationType.RETURN),
+    ],
+    "partial_function_comment_no_ellipsis": [
+        typed_arg(argname="arg1"),
+        untyped_arg(argname="arg2"),
+        typed_arg(argname="return", annotation_type=AnnotationType.RETURN),
+    ],
+    "partial_function_comment_with_ellipsis": [
+        untyped_arg(argname="arg1"),
+        typed_arg(argname="arg2"),
+        typed_arg(argname="return", annotation_type=AnnotationType.RETURN),
+    ],
+    "argument_comments_ellipsis_function_comment": [
+        typed_arg(argname="arg1"),
+        typed_arg(argname="arg2"),
+        typed_arg(argname="return", annotation_type=AnnotationType.RETURN),
+    ],
+    "argument_comments_no_function_comment": [
+        typed_arg(argname="arg1"),
+        typed_arg(argname="arg2"),
+        untyped_arg(argname="return", annotation_type=AnnotationType.RETURN),
+    ],
+    "mixed_argument_hint_types": [
+        typed_arg(argname="arg1"),
+        typed_arg(argname="arg2", has_type_comment=False, has_3107_annotation=True),
+        untyped_arg(argname="return", annotation_type=AnnotationType.RETURN),
+    ],
+    "duplicate_argument_hint_types": [
+        typed_arg(argname="arg1"),
+        typed_arg(argname="arg2", has_type_comment=True, has_3107_annotation=True),
+        untyped_arg(argname="return", annotation_type=AnnotationType.RETURN),
+    ],
+    "arg_comment_return_annotation_hint_types": [
+        typed_arg(argname="arg1"),
+        typed_arg(argname="arg2"),
+        typed_arg(
+            argname="return",
+            annotation_type=AnnotationType.RETURN,
+            has_type_comment=False,
+            has_3107_annotation=True,
+        ),
+    ],
+    "arg_annotation_return_comment_hint_types": [
+        typed_arg(argname="arg1", has_type_comment=False, has_3107_annotation=True),
+        typed_arg(argname="arg2", has_type_comment=False, has_3107_annotation=True),
+        typed_arg(argname="return", annotation_type=AnnotationType.RETURN, has_type_comment=True),
+    ],
+}


### PR DESCRIPTION
PR for v1.1.0 Release

### Added
* #35: Issue templates
* #36: Support for PEP 484-style type comments
* #36: Add `TYP301` for presence of type comment & type annotation for same entity
* #36: Add `error_code.from_function` class method to generate argument for an entire function
* #38: Improve `setup.py` metadata

### Fixed
* #32: Incorrect line number for return values in the presence of multiline docstrings
* #33: Improper handling of nested functions in class methods
* `setup.py` dev dependencies out of sync with Pipfile
* Incorrect order of arguments in `Argument` and `Function` `__repr__` methods

Closes: #32
Closes: #33 
Closes: #35 
Closes: #36