### PR TITLE
Fix Tox test execution on Windows

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,7 @@ minversion = 3.14.0
 isolated_build = True
 
 [testenv]
-commands = python3 -m pytest
+commands = python -m pytest
 deps =
     pytest
     pytest-check


### PR DESCRIPTION
Running the tests is not currently possible on Windows, and will fail with `ERROR: InvocationError for command could not find executable python3`. This is because Tox executes `pytest` using `python3`, which isn't a valid python command on Windows. Since the Tox runs the tests in a virtual environment, plain `python` can be safely used.

Tested against Python 3.6 and 3.6 on Windows (PowerShell) and 3.7 in Ubuntu (WSL).