### PR TITLE
Release v2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (`<ma
 
 ## [v2.3.0]
 ### Added
-* #87 Add `--mypy-style-init-return` to allow omission of a return type hint for `__init__` if at least one argument is annotated. See [mypy's documentation](https://mypy.readthedocs.io/en/stable/class_basics.html?#annotating-init-methods) for additional details.
+* #87 Add `--mypy-init-return` to allow omission of a return type hint for `__init__` if at least one argument is annotated. See [mypy's documentation](https://mypy.readthedocs.io/en/stable/class_basics.html?#annotating-init-methods) for additional details.
 
 ## [v2.2.1]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (`<major>`.`<minor>`.`<patch>`)
 
+## [v2.3.0]
+### Added
+* #87 Add `--mypy-style-init-return` to allow omission of a return type hint for `__init__` if at least one argument is annotated. See [mypy's documentation](https://mypy.readthedocs.io/en/stable/class_basics.html?#annotating-init-methods) for additional details.
+
 ## [v2.2.1]
 ### Fixed
 * #89 Revert change to Python version pinning to prevent unnecessary locking headaches

--- a/README.md
+++ b/README.md
@@ -4,13 +4,11 @@
 [![Build Status](https://dev.azure.com/python-discord/Python%20Discord/_apis/build/status/python-discord.flake8-annotations?branchName=master)](https://dev.azure.com/python-discord/Python%20Discord/_build/latest?definitionId=16&branchName=master)
 [![Discord](https://img.shields.io/static/v1?label=Python%20Discord&logo=discord&message=%3E30k%20members&color=%237289DA&logoColor=white)](https://discord.gg/2B963hn)
 
-
 `flake8-annotations` is a plugin for [Flake8](http://flake8.pycqa.org/en/latest/) that detects the absence of [PEP 3107-style](https://www.python.org/dev/peps/pep-3107/) function annotations and [PEP 484-style](https://www.python.org/dev/peps/pep-0484/#type-comments) type comments  (see: [Caveats](#Caveats-for-PEP-484-style-Type-Comments)).
 
 What this won't do: Check variable annotations (see: [PEP 526](https://www.python.org/dev/peps/pep-0526/)), respect stub files, or replace [mypy](http://mypy-lang.org/).
 
 ## Installation
-
 Install from PyPi with your favorite `pip` invocation:
 
 ```bash
@@ -23,7 +21,7 @@ You can verify it's being picked up by invoking the following in your shell:
 
 ```bash
 $ flake8 --version
-3.8.2 (flake8-annotations: 2.2.1, mccabe: 0.6.1, pycodestyle: 5.0.2, pyflakes: 2.2.0) CPython 3.8.2 on Darwin
+3.8.3 (flake8-annotations: 2.3.0, mccabe: 0.6.1, pycodestyle: 2.6.2, pyflakes: 2.2.0) CPython 3.8.2 on Darwin
 ```
 
 ## Table of Warnings
@@ -60,7 +58,6 @@ All warnings are enabled by default.
 **Notes:**
 1. See: [PEP 484](https://www.python.org/dev/peps/pep-0484/#annotating-instance-and-class-methods) and [PEP 563](https://www.python.org/dev/peps/pep-0563/) for suggestions on annotating `self` and `cls` arguments.
 
-
 ## Configuration Options
 Some opinionated flags are provided to tailor the linting errors emitted:
 
@@ -81,6 +78,10 @@ Suppress all errors for dynamically typed functions. A function is considered dy
 
 Default: `False`
 
+### `--mypy-init-return`: `bool`
+Allow omission of a return type hint for `__init__` if at least one argument is annotated. See [mypy's documentation](https://mypy.readthedocs.io/en/stable/class_basics.html?#annotating-init-methods) for additional details.
+
+Default: `False`
 
 ## Caveats for PEP 484-style Type Comments
 ### Function type comments

--- a/flake8_annotations/__init__.py
+++ b/flake8_annotations/__init__.py
@@ -17,7 +17,7 @@ else:
 
     PY_GTE_38 = False
 
-__version__ = "2.2.1"
+__version__ = "2.3.0"
 
 AST_ARG_TYPES = ("args", "vararg", "kwonlyargs", "kwarg")
 if PY_GTE_38:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "flake8-annotations"
-version = "2.2.1"
+version = "2.3.0"
 description = "Flake8 Type Annotation Checks"
 license = "MIT"
 readme = "README.md"

--- a/testing/helpers.py
+++ b/testing/helpers.py
@@ -30,6 +30,7 @@ def check_source(
     suppress_none_returns: bool = False,
     suppress_dummy_args: bool = False,
     allow_untyped_defs: bool = False,
+    mypy_init_return: bool = False,
 ) -> Generator[Error, None, None]:
     """Helper for generating linting errors from the provided source code."""
     _, lines = parse_source(src)
@@ -39,6 +40,7 @@ def check_source(
     checker_instance.suppress_none_returning = suppress_none_returns
     checker_instance.suppress_dummy_args = suppress_dummy_args
     checker_instance.allow_untyped_defs = allow_untyped_defs
+    checker_instance.mypy_init_return = mypy_init_return
 
     return checker_instance.run()
 

--- a/testing/test_cases/mypy_init_return_test_cases.py
+++ b/testing/test_cases/mypy_init_return_test_cases.py
@@ -1,0 +1,92 @@
+from textwrap import dedent
+from typing import NamedTuple
+
+
+class MypyInitReturnTestCase(NamedTuple):
+    """
+    Helper container for testing mypy-style omission of __init__ return hints.
+
+    Mypy allows the omission of return type hints if at least one argument is annotated.
+    """
+
+    src: str
+    should_yield_return_error: bool
+
+
+mypy_init_test_cases = {
+    "no_args_no_return": MypyInitReturnTestCase(
+        src=dedent(
+            """\
+            class Foo:
+
+                def __init__(self):
+                    ...
+            """
+        ),
+        should_yield_return_error=True,
+    ),
+    "arg_no_hint_no_return": MypyInitReturnTestCase(
+        src=dedent(
+            """\
+            class Foo:
+
+                def __init__(self, foo):
+                    ...
+            """
+        ),
+        should_yield_return_error=True,
+    ),
+    "arg_no_hint_return": MypyInitReturnTestCase(
+        src=dedent(
+            """\
+            class Foo:
+
+                def __init__(self, foo) -> None:
+                    ...
+            """
+        ),
+        should_yield_return_error=False,
+    ),
+    "no_arg_return": MypyInitReturnTestCase(
+        src=dedent(
+            """\
+            class Foo:
+
+                def __init__(self) -> None:
+                    ...
+            """
+        ),
+        should_yield_return_error=False,
+    ),
+    "arg_hint_no_return": MypyInitReturnTestCase(
+        src=dedent(
+            """\
+            class Foo:
+
+                def __init__(self, foo: int):
+                    ...
+            """
+        ),
+        should_yield_return_error=False,
+    ),
+    "arg_hint_return": MypyInitReturnTestCase(
+        src=dedent(
+            """\
+            class Foo:
+
+                def __init__(self, foo: int) -> None:
+                    ...
+            """
+        ),
+        should_yield_return_error=False,
+    ),
+    "cheeky_non_method_init": MypyInitReturnTestCase(
+        src=dedent(
+            """\
+            def __init__(self, foo: int):
+                ...
+            """
+        ),
+        should_yield_return_error=True,
+    ),
+}

--- a/testing/test_dynamic_function_error_suppression.py
+++ b/testing/test_dynamic_function_error_suppression.py
@@ -41,10 +41,7 @@ class TestDynamicallyTypedFunctionErrorSuppression:
         test_case_name, test_case, errors = yielded_errors
         failure_msg = f"Check failed for case '{test_case_name}'"
 
-        print(errors)
         if test_case.should_yield_error:
-            print("Should yield error")
             check_is_not_empty(errors, msg=failure_msg)
         else:
-            print("Should not yield error")
             check_is_empty(errors, msg=failure_msg)

--- a/testing/test_mypy_init_return.py
+++ b/testing/test_mypy_init_return.py
@@ -1,0 +1,48 @@
+from typing import Tuple
+
+import pytest
+import pytest_check as check
+from flake8_annotations.error_codes import Error
+from testing.helpers import check_source
+
+from .test_cases.mypy_init_return_test_cases import (
+    MypyInitReturnTestCase,
+    mypy_init_test_cases,
+)
+
+
+class TestMypyStyleInitReturnErrorSuppression:
+    """Test Mypy-style omission of return type hints for typed __init__ methods."""
+
+    @pytest.fixture(params=mypy_init_test_cases.items(), ids=mypy_init_test_cases.keys())
+    def yielded_errors(
+        self, request  # noqa: ANN001
+    ) -> Tuple[str, MypyInitReturnTestCase, Tuple[Error]]:
+        """
+        Build a fixture for the error codes emitted from parsing the Mypy __init__ return test code.
+
+        Fixture provides a tuple of: test case name, its corresponding MypyInitReturnTestCase
+        instance, and a tuple of the errors yielded by the checker
+        """
+        test_case_name, test_case = request.param
+
+        return (
+            test_case_name,
+            test_case,
+            tuple(check_source(test_case.src, mypy_init_return=True)),
+        )
+
+    def test_suppressed_return_error(
+        self, yielded_errors: Tuple[str, MypyInitReturnTestCase, Tuple[Error]]
+    ) -> None:
+        """
+        Test that ANN200 level errors are suppressed in class __init__ according to Mypy's behavior.
+
+        Mypy allows omission of the return type hint for __init__ methods if at least one argument
+        is annotated.
+        """
+        test_case_name, test_case, errors = yielded_errors
+        failure_msg = f"Check failed for case '{test_case_name}'"
+
+        yielded_ANN200 = any("ANN2" in error[2] for error in yielded_errors[2])
+        check.equal(test_case.should_yield_return_error, yielded_ANN200, msg=failure_msg)


### PR DESCRIPTION
# Changelog

## [v2.3.0]
### Added
* #87 Add `--mypy-init-return` to allow omission of a return type hint for `__init__` if at least one argument is annotated.

# Additional Details
To help provide compatibility with Mypy for maintainers that wish to do so, the `--mypy-init-return` flag has been introduced to mimic Mypy's allowance for the omission of return type hints for `__init__` methods that are not dynamically typed (at least one argument is annotated). With this flag set, `ANN200` level errors will be suppressed for `__init__` methods if at least one argument is explicitly annotated.

For example, from Mypy's documentation:

```py
class C1:  # Fully annotated
    def __init__(self) -> None:
        self.var = 42

class C2:  # Fully annotated
    def __init__(self, arg: int):
        self.var = arg

class C3:
    def __init__(self):  # Not fully annotated
        # This body is not type checked
        self.var = 42 + 'abc'
```

**NOTE:** By default, Mypy does not enforce annotations for `self` in class methods, so to completely mimic Mypy's behavior with `flake8-annotations` `ANN101` will need to be added to the repository's ignored linting codes.


See Mypy's documentation for additional details: https://mypy.readthedocs.io/en/stable/class_basics.html?#annotating-init-methods

Closes #87